### PR TITLE
фикс jwt-secret в cli аргументах

### DIFF
--- a/cmd/npchat/main.go
+++ b/cmd/npchat/main.go
@@ -68,6 +68,12 @@ func initCliCommand() *cli.Command {
 				Required:    true,
 			},
 			&cli.StringFlag{
+				Name:        "jwt-secret",
+				Destination: &cfg.JwtSecret,
+				Usage:       "Секрет jwt подписи",
+				Required:    true,
+			},
+			&cli.StringFlag{
 				Name:        "http-addr",
 				Destination: &cfg.Http2.HttpAddr,
 				Usage:       "Адрес для запуска HTTP сервера",
@@ -110,11 +116,6 @@ func initCliCommand() *cli.Command {
 				Name:        "oauth-github-callback",
 				Destination: &cfg.OauthGithub.RedirectURL,
 				Usage:       "URL для перенаправления после аутентификации OAuth Github",
-			},
-			&cli.StringFlag{
-				Name:        "jwt-secret",
-				Destination: &cfg.JwtSecret,
-				Usage:       "Секрет jwt подписи",
 			},
 		},
 	}

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -41,6 +41,8 @@ services:
       - "${OAUTH_GITHUB_SECRET}"
       - "--oauth-github-callback"
       - "${OAUTH_GITHUB_CALLBACK}"
+      - "--jwt-secret"
+      - "${AUTH_JWT_SECRET}"
 
   test.npchat:
     container_name: npc.test.npchat
@@ -61,6 +63,8 @@ services:
       - "postgresql://postgres:postgres@test.pgsql:5432/test_npc_db?sslmode=disable"
       - "--log-level"
       - "debug"
+      - "--jwt-secret"
+      - "qwerty"
 
 # https://github.com/docker-library/docs/blob/master/postgres/README.md
   test.pgsql:

--- a/internal/adapter/jwt/jwt_create/jwt_creator.go
+++ b/internal/adapter/jwt/jwt_create/jwt_creator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cristalhq/jwt/v5"
 	"github.com/google/uuid"
+
 	"github.com/nice-pea/npchat/internal/domain/sessionn"
 )
 
@@ -18,7 +19,7 @@ type customClaims struct {
 	jwt.RegisteredClaims
 }
 
-// создает jwt на основе некоторых данных из session
+// Issue создает jwt на основе некоторых данных из session
 func (c *Issuer) Issue(session sessionn.Session) (string, error) {
 	// создаем claims
 	claims := customClaims{


### PR DESCRIPTION
## Summary by Sourcery

Require the jwt-secret flag in the CLI, propagate it through Docker Compose, and correct a comment in the JWT creator.

Bug Fixes:
- Make the jwt-secret CLI flag required and remove its duplicate definition

Deployment:
- Add the --jwt-secret flag and AUTH_JWT_SECRET environment variable to Docker Compose for both services

Chores:
- Fix the comment in jwt_creator.go to reference the Issue method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Новые возможности
  * В CLI добавлен обязательный флаг для указания секрета JWT; запуск без него невозможен.
* Chores
  * Обновлены конфигурации docker-compose для сервисов npc.npchat и test.npchat: к командам добавлен флаг передачи JWT-секрета (через переменную окружения/константу).
* Style
  * Незначительные правки комментариев и форматирования без изменения поведения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->