### PR TITLE
Работа с lastactiveat в репозитории

### DIFF
--- a/internal/domain/chatt/repository.go
+++ b/internal/domain/chatt/repository.go
@@ -1,6 +1,10 @@
 package chatt
 
-import "github.com/google/uuid"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // Repository представляет собой интерфейс для работы с репозиторием чатов.
 type Repository interface {
@@ -15,6 +19,7 @@ type Filter struct {
 	InvitationID          uuid.UUID // Фильтрация по ID приглашений в чате
 	InvitationRecipientID uuid.UUID // Фильтрация по ID получателей приглашения в чат
 	ParticipantID         uuid.UUID // Фильтрация по ID участников в чате
+	ActiveBefore          time.Time // Брать записи где LastActiveAt меньше чем ActiveBefore
 }
 
 // Find возвращает чат либо ошибку ErrChatNotExists

--- a/internal/domain/chatt/repository.go
+++ b/internal/domain/chatt/repository.go
@@ -20,6 +20,7 @@ type Filter struct {
 	InvitationRecipientID uuid.UUID // Фильтрация по ID получателей приглашения в чат
 	ParticipantID         uuid.UUID // Фильтрация по ID участников в чате
 	ActiveBefore          time.Time // Брать записи где LastActiveAt меньше чем ActiveBefore
+	Limit                 int       // Ограничить количество элементов
 }
 
 // Find возвращает чат либо ошибку ErrChatNotExists

--- a/internal/repository/pgsql_repository/chatt_repository.go
+++ b/internal/repository/pgsql_repository/chatt_repository.go
@@ -43,7 +43,7 @@ func (r *ChattRepository) List(filter chatt.Filter) ([]chatt.Chat, error) {
 		where = where.And("c.id = ?", filter.ID)
 	}
 
-	query, args, err := bqb.New("? ? GROUP BY c.id", sel, where).ToPgsql()
+	query, args, err := bqb.New("? ? GROUP BY c.id ORDER BY last_active_at DESC", sel, where).ToPgsql()
 	if err != nil {
 		return nil, fmt.Errorf("bqb.ToPgsql: %w", err)
 	}

--- a/internal/repository/pgsql_repository/chatt_repository.go
+++ b/internal/repository/pgsql_repository/chatt_repository.go
@@ -43,6 +43,10 @@ func (r *ChattRepository) List(filter chatt.Filter) ([]chatt.Chat, error) {
 		where = where.And("c.id = ?", filter.ID)
 	}
 
+	if !filter.ActiveBefore.IsZero() {
+		where = where.And("c.last_active_at < ?", filter.ActiveBefore)
+	}
+
 	query, args, err := bqb.New("? ? GROUP BY c.id ORDER BY last_active_at DESC", sel, where).ToPgsql()
 	if err != nil {
 		return nil, fmt.Errorf("bqb.ToPgsql: %w", err)

--- a/internal/repository/pgsql_repository/chatt_repository.go
+++ b/internal/repository/pgsql_repository/chatt_repository.go
@@ -129,7 +129,8 @@ func (r *ChattRepository) upsert(chat chatt.Chat) error {
 		VALUES (:id, :name, :chief_id, :last_active_at)
 		ON CONFLICT (id) DO UPDATE SET
 			name=excluded.name,
-			chief_id=excluded.chief_id
+			chief_id=excluded.chief_id,
+			last_active_at=excluded.last_active_at
 	`, toDBChat(chat)); err != nil {
 		return fmt.Errorf("r.DB().NamedExec: %w", err)
 	}

--- a/internal/repository/pgsql_repository/chatt_repository_test.go
+++ b/internal/repository/pgsql_repository/chatt_repository_test.go
@@ -1,7 +1,6 @@
 package pgsqlRepository
 
 import (
-	"slices"
 	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
@@ -150,9 +149,10 @@ func (suite *Suite) Test_ChattRepository() {
 			})
 			suite.NoError(err)
 			suite.Require().Len(chatsFromRepo, limit)
-			slices.Reverse(createdChats)
-			for i, chat := range createdChats[:limit] {
-				suite.Equal(chatsFromRepo[i], chat)
+
+			for i := 0; i < limit; i++ {
+				expectedIdx := len(createdChats) - 1 - i
+				suite.Equal(createdChats[expectedIdx], chatsFromRepo[i])
 			}
 		})
 


### PR DESCRIPTION
## Summary by Sourcery

Support filtering and limiting chat listings by last active timestamp, ensure descending order by LastActiveAt, and normalize timestamps to UTC

New Features:
- Add ActiveBefore filter to retrieve chats with LastActiveAt earlier than a specified time
- Add Limit filter to restrict the number of chats returned

Enhancements:
- Sort returned chats by LastActiveAt in descending order
- Normalize LastActiveAt timestamps to UTC in domain mapping

Tests:
- Add tests verifying ActiveBefore filter behavior
- Add tests verifying Limit filter and returned order
- Add test ensuring chats are sorted by LastActiveAt descending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Новые возможности
  - Фильтрация чатов по дате последней активности (показывать чаты с LastActiveAt < заданного времени).
  - Ограничение количества выдаваемых чатов (Limit) для удобной выборки/пагинации.

- Улучшения
  - Стабильная сортировка чатов по убыванию LastActiveAt.
  - Нормализация времени LastActiveAt в UTC.

- Тесты
  - Расширено покрытие: сценарии для ActiveBefore, Limit, комбинированных фильтров и проверки порядка.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->