### PR TITLE
Разрешить воркфлоу Bump version запускать на master

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -24,10 +24,10 @@ jobs:
   bump_version:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if current ref is a tag
+      - name: Check if current ref is a tag or master branch
         run: |
-          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "❌ Workflow может быть запущен только из тега."
+          if [[ "${{ github.ref }}" != refs/tags/* && "${{ github.ref }}" != "refs/heads/master" ]]; then
+            echo "❌ Workflow может быть запущен только из тега или ветки master."
             exit 1
           fi
 
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
           TAG_PREFIX: v
-          TAG_CONTEXT: branch
+          TAG_CONTEXT: ${{ github.ref == 'refs/heads/master' && 'repo' || 'branch' }}
           PRERELEASE: ${{ inputs.label != '' }}
           PRERELEASE_SUFFIX: ${{ inputs.label }}
           DEFAULT_BUMP: ${{ inputs.level }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/nice-pea/npchat/issues/127
+Your prepared branch: issue-127-b660ade1
+Your prepared working directory: /tmp/gh-issue-solver-1759429497154
+Your forked repository: konard/npchat
+Original repository (upstream): nice-pea/npchat
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/nice-pea/npchat/issues/127
-Your prepared branch: issue-127-b660ade1
-Your prepared working directory: /tmp/gh-issue-solver-1759429497154
-Your forked repository: konard/npchat
-Original repository (upstream): nice-pea/npchat
-
-Proceed.


### PR DESCRIPTION
## Решение

Разрешён запуск workflow `Bump version` как из тегов, так и из ветки master. При запуске с ветки master параметр `TAG_CONTEXT` автоматически устанавливается в значение `repo`.

### Изменения

1. **Проверка ref**: Обновлена проверка в шаге "Check if current ref is a tag or master branch" для разрешения запуска из:
   - Тегов (`refs/tags/*`) - как раньше
   - Ветки master (`refs/heads/master`) - новое поведение

2. **TAG_CONTEXT**: Добавлено условное определение значения:
   - `repo` - при запуске с ветки master
   - `branch` - при запуске с тега

### Файлы

- `.github/workflows/bump-version.yml` - обновлён workflow

Fixes #127

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>